### PR TITLE
typo in variable name

### DIFF
--- a/scripts/1-clean.R
+++ b/scripts/1-clean.R
@@ -78,7 +78,7 @@ sapa = sapa %>%
          z.p2edu = scale(p2edu),
          z.p1occIncomeEst = scale(p1occIncomeEst),
          z.p2occIncomeEst = scale(p2occIncomeEst),
-         z.p2occPrestige = scale(p1occPrestige),
+         z.p1occPrestige = scale(p1occPrestige),
          z.p2occPrestige = scale(p2occPrestige)) 
 
 sapa$ses = rowMeans(sapa[,grepl("^z\\.", names(sapa))], na.rm=T)


### PR DESCRIPTION
Hi Sara,

As I was looking through your code, I noticed a small (but potentially important) typo when you're scaling the SES variables. Specifically, you create the "z.p2occPrestige" variable twice and are left without the "z.p1occPrestige" variable when you create the SES composite score. This typo also exists in the "pre-registered" version of your script, but I didn't change that version, as I assumed you'd want to keep that as is. 

-Brendan